### PR TITLE
Fix Chinese translation of neutral faction name

### DIFF
--- a/chinese-translation/content/config/vcmi-chinese/game.json
+++ b/chinese-translation/content/config/vcmi-chinese/game.json
@@ -4838,7 +4838,7 @@
 	"faction.core.necropolis.randomName.7": "黑鸦城",
 	"faction.core.necropolis.randomName.8": "乌云城",
 	"faction.core.necropolis.randomName.9": "克德索",
-	"faction.core.neutral.name": "Neutral",
+	"faction.core.neutral.name": "中立",
 	"faction.core.rampart.name": "壁垒",
 	"faction.core.rampart.randomName.0": "神木堡",
 	"faction.core.rampart.randomName.10": "思强格",


### PR DESCRIPTION
<img width="503" height="677" alt="PixPin_2026-08-10_21-32-47" src="https://github.com/user-attachments/assets/c46bb4ad-d4f7-4ab5-adbb-9090e4f70ece" />

在英雄无敌百科中，生物列表副标题的"中立"仍然是英文。